### PR TITLE
Disable jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,3 @@ org.gradle.parallel=true
 
 # AndroidX
 android.useAndroidX=true
-android.enableJetifier=true


### PR DESCRIPTION
Jetifier can be disabled, all the libraries being used do not depend on old support libraries.

`enableJetifier` is `false` by default https://developer.android.com/jetpack/androidx#using_androidx_libraries_in_your_project