### PR TITLE
Bump compose compiler to 1.2.0

### DIFF
--- a/.github/workflows/android-lint.yml
+++ b/.github/workflows/android-lint.yml
@@ -1,5 +1,11 @@
 name: Style
+
 on: push
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -1,5 +1,11 @@
 name: Test
+
 on: push
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: macos-latest
@@ -16,7 +22,6 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-            ~/.gradle/configuration-cache
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-

--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -22,6 +22,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
+            ~/.gradle/configuration-cache
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,6 @@ android {
 
         versionCode 1
         versionName "1.0"
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
@@ -18,14 +16,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
-    }
-
-    buildFeatures {
-        compose true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion rootProject.compose_version
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = "1.6.10"
+    ext.kotlin_version = "1.7.0"
     ext.dagger_version = "2.42"
     ext.compose_version = "1.1.1"
 
@@ -39,7 +39,7 @@ subprojects {
                 buildToolsVersion "32.0.0"
 
                 defaultConfig {
-                    minSdkVersion 23
+                    minSdkVersion 24
                     targetSdkVersion 32
 
                     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -55,7 +55,7 @@ subprojects {
                 }
 
                 composeOptions {
-                    kotlinCompilerExtensionVersion rootProject.compose_version
+                    kotlinCompilerExtensionVersion "1.2.0"
                 }
 
                 packagingOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,7 @@ android.nonTransitiveRClass=true
 
 # Configuration cache https://docs.gradle.org/current/userguide/configuration_cache.html
 org.gradle.unsafe.configuration-cache=true
+
+# Disable this property as we don't use KMP here and it breaks configuration caching
+# https://youtrack.jetbrains.com/issue/KT-52694
+kotlin.mpp.enableKotlinToolingMetadataArtifact=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -7,7 +7,7 @@ configurations {
 }
 
 dependencies {
-    ktlint("com.pinterest:ktlint:0.46.0") {
+    ktlint("com.pinterest:ktlint:0.46.1") {
         attributes {
             attribute(Bundling.BUNDLING_ATTRIBUTE, getObjects().named(Bundling, Bundling.EXTERNAL))
         }


### PR DESCRIPTION
From now on there's going to be [independent versioning of Jetpack Compose libraries](https://android-developers.googleblog.com/2022/06/independent-versioning-of-Jetpack-Compose-libraries.html)
