### PR TITLE
Use Compose Bill of Materials

### DIFF
--- a/build-conventions/src/main/groovy/android-composable-conventions.gradle
+++ b/build-conventions/src/main/groovy/android-composable-conventions.gradle
@@ -13,6 +13,9 @@ android {
 }
 
 dependencies {
+    implementation platform(libs.compose.bom)
+    androidTestImplementation platform(libs.compose.bom)
+
     implementation libs.androidx.hilt.navigation.compose
 
     implementation libs.compose.ui

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,42 +2,43 @@
 androidGradlePlugin = "8.12.1"
 kotlin = "2.2.10"
 dagger = "2.57.1"
-compose = "1.9.0"
+androidxComposeBom = "2025.08.00"
 hiltAndroidX = "1.2.0"
 screenshot = "0.0.1-alpha11"
 
 [libraries]
-ktlint-cli = { module = "com.pinterest.ktlint:ktlint-cli", version = "1.7.1" }
-ktlint-compose = { module = "io.nlopez.compose.rules:ktlint", version = "0.4.27" }
+ktlint-cli = { group = "com.pinterest.ktlint", name = "ktlint-cli", version = "1.7.1" }
+ktlint-compose = { group = "io.nlopez.compose.rules", name = "ktlint", version = "0.4.27" }
 
-kotlin = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
-appcompat = { module = "androidx.appcompat:appcompat", version = "1.7.1" }
-dagger = { module = "com.google.dagger:dagger", version.ref = "dagger" }
-dagger-compiler = { module = "com.google.dagger:dagger-compiler", version.ref = "dagger" }
-androidx-core = { module = "androidx.core:core-ktx", version = "1.16.0" }
+kotlin = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
+appcompat = { group = "androidx.appcompat", name = "appcompat", version = "1.7.1" }
+dagger = { group = "com.google.dagger", name = "dagger", version.ref = "dagger" }
+dagger-compiler = { group = "com.google.dagger", name = "dagger-compiler", version.ref = "dagger" }
+androidx-core = { group = "androidx.core", name = "core-ktx", version = "1.16.0" }
 
 # Hilt
-hilt = { module = "com.google.dagger:hilt-android", version.ref = "dagger" }
-hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "dagger" }
-androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "hiltAndroidX" }
-androidx-hilt-navigation = { module = "androidx.hilt:hilt-navigation", version.ref = "hiltAndroidX" }
-androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version = "1.2.0" }
+hilt = { group = "com.google.dagger", name = "hilt-android", version.ref = "dagger" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "dagger" }
+androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltAndroidX" }
+androidx-hilt-navigation = { group = "androidx.hilt", name = "hilt-navigation", version.ref = "hiltAndroidX" }
+androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version = "1.2.0" }
 
-junit = { module = "junit:junit", version = "4.13.2" }
-androidx-test-junit = { module = "androidx.test.ext:junit", version = "1.3.0" }
-androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version = "3.7.0" }
+junit = { group = "junit", name = "junit", version = "4.13.2" }
+androidx-test-junit = { group = "androidx.test.ext", name = "junit", version = "1.3.0" }
+androidx-test-espresso = { group = "androidx.test.espresso", name = "espresso-core", version = "3.7.0" }
 
 # Compose
-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
-compose-ui-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "compose" }
-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
-compose-material = { module = "androidx.compose.material3:material3", version = "1.3.2" }
-compose-navigation = { module = "androidx.navigation:navigation-compose", version = "2.9.3" }
-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version = "2.9.2" }
+compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
+compose-ui = { group = "androidx.compose.ui", name = "ui" }
+compose-ui-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+compose-material = { group = "androidx.compose.material3", name = "material3" }
+compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version = "2.9.3" }
+lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version = "2.9.2" }
 
 # Compose UI test
-compose-ui-test-junit = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
+compose-ui-test-junit = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 screenshot-validation-api = { group = "com.android.tools.screenshot", name = "screenshot-validation-api", version.ref = "screenshot"}
 
 [plugins]


### PR DESCRIPTION
This pull request updates the way Compose dependencies are managed and modernizes the dependency declarations in the project. The most significant change is the adoption of the Compose BOM (Bill of Materials) for more reliable version alignment across Compose libraries, and a refactor of the dependency specification format in `gradle/libs.versions.toml` for improved clarity and maintainability.

**Compose Dependency Management:**
* Switched to using the Compose BOM (`compose-bom`) for both implementation and Android test dependencies in `android-composable-conventions.gradle`, ensuring consistent Compose library versions.
* Updated the Compose version reference in `gradle/libs.versions.toml` to use `androidxComposeBom` and added the `compose-bom` library entry.

**Dependency Declaration Refactor:**
* Refactored all dependency entries in `gradle/libs.versions.toml` from the old `module` format to the newer, more explicit `group`, `name`, and `version` format for better readability and maintainability.
* Removed explicit Compose versions from individual Compose libraries in `gradle/libs.versions.toml`, allowing the BOM to manage versions automatically.