### PR TITLE
build: skip subprojects without build files in root configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,12 @@ plugins {
     alias libs.plugins.android.library apply false
     alias libs.plugins.kotlin.gradle apply false
     alias libs.plugins.dagger.hilt apply false
-    alias(libs.plugins.compose.compiler) apply false
+    alias libs.plugins.compose.compiler apply false
     alias libs.plugins.compose.screenshot apply false
 }
 
 subprojects {
+    if (!project.buildFile.exists()) return // Skip intermediate projects without physical build file
+
     apply from: "$rootDir/ktlint.gradle"
 }


### PR DESCRIPTION
Ensures intermediate container directories in multi-project builds (like ':features') are ignored by the subprojects block configuration if they lack a physical build file.